### PR TITLE
Added windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.31)
+project(HotSpotter)
+
+set(CMAKE_CXX_STANDARD 20)
+
+add_subdirectory("${PROJECT_SOURCE_DIR}/client" "${PROJECT_SOURCE_DIR}/client/out")
+add_subdirectory("${PROJECT_SOURCE_DIR}/injector" "${PROJECT_SOURCE_DIR}/injector/out")

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
     - Select instance to view/patch fields
 - [ ] Patch fields (value, access modifiers)
 - [ ] Patch/replace method bytecode (if technically possible)
+- [ ] Runtime Renaming/Remapping of methods/fields/classes
 
 ---
 

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,10 +1,24 @@
 cmake_minimum_required(VERSION 3.31)
 project(client)
 
+if (WIN32)
+    set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif ()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(WIN32)
+    #    add_definitions(-DUNICODE -D_UNICODE)
+    add_definitions(-D_MBCS)
+endif()
+
 find_package(OpenGL REQUIRED)
+
+set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+
 add_subdirectory(external/glfw)
 
 set(IMGUI_SOURCES
@@ -28,33 +42,49 @@ set(IMGUI_SOURCES
         src/gui/components/FileTree.hpp
 )
 
+# Platform-specific entry points
+if(WIN32)
+    set(PLATFORM_ENTRY_POINT
+            src/platform/dllmain.cpp
+            src/platform/windows_utils.h
+    )
+elseif(UNIX)
+    set(PLATFORM_ENTRY_POINT src/platform/library.cpp)
+else()
+    message(FATAL_ERROR "Unsupported platform")
+endif()
 
 add_library(client SHARED
-        src/library.cpp
+        ${PLATFORM_ENTRY_POINT}
         src/hot_spotter.cpp
         ${IMGUI_SOURCES}
 )
 
+# Common include directories
 target_include_directories(client PRIVATE
         external/imgui
         external/imgui/backends
         external/glfw/include
         external/java
-        external/java/linux
 )
 
-target_link_libraries(client PRIVATE
-        glfw
-        ${OPENGL_LIBRARIES}
-        dl pthread
-)
-
+# Platform-specific configurations
 if(WIN32)
-    message(FATAL_ERROR "Not yet implemented")
+    message(STATUS "Building for Windows")
+    target_sources(client PRIVATE src/logger/impl/logger_windows.cpp)
+    target_sources(client PRIVATE src/attacher/impl/WindowsAttacher.cpp)
+    target_include_directories(client PRIVATE external/java/windows)
 elseif(UNIX)
     message(STATUS "Building for Linux/Unix")
     target_sources(client PRIVATE src/logger/impl/logger_linux.cpp)
     target_sources(client PRIVATE src/attacher/impl/LinuxAttacher.cpp)
+    target_include_directories(client PRIVATE external/java/linux)
+    target_link_libraries(client PRIVATE dl pthread)
 else()
     message(FATAL_ERROR "Unsupported platform")
 endif()
+
+target_link_libraries(client PRIVATE
+        glfw
+        ${OPENGL_LIBRARIES}
+)

--- a/client/external/java/windows/jawt_md.h
+++ b/client/external/java/windows/jawt_md.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+#ifndef _JAVASOFT_JAWT_MD_H_
+#define _JAVASOFT_JAWT_MD_H_
+
+#include <windows.h>
+#include "jawt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Win32-specific declarations for AWT native interface.
+ * See notes in jawt.h for an example of use.
+ */
+typedef struct jawt_Win32DrawingSurfaceInfo {
+    /* Native window, DDB, or DIB handle */
+    union {
+        HWND hwnd;
+        HBITMAP hbitmap;
+        void* pbits;
+    };
+    /*
+     * This HDC should always be used instead of the HDC returned from
+     * BeginPaint() or any calls to GetDC().
+     */
+    HDC hdc;
+    HPALETTE hpalette;
+} JAWT_Win32DrawingSurfaceInfo;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_JAVASOFT_JAWT_MD_H_ */

--- a/client/external/java/windows/jni_md.h
+++ b/client/external/java/windows/jni_md.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+#ifndef _JAVASOFT_JNI_MD_H_
+#define _JAVASOFT_JNI_MD_H_
+
+#ifndef JNIEXPORT
+  #define JNIEXPORT __declspec(dllexport)
+#endif
+#define JNIIMPORT __declspec(dllimport)
+#define JNICALL __stdcall
+
+typedef int jint;
+typedef long long jlong;
+typedef signed char jbyte;
+
+#endif /* !_JAVASOFT_JNI_MD_H_ */

--- a/client/src/attacher/impl/WindowsAttacher.cpp
+++ b/client/src/attacher/impl/WindowsAttacher.cpp
@@ -15,7 +15,7 @@ public:
             return false;
         }
 
-        // Define function pointer type for JNI_GetCreatedJavaVMs
+
         using t_JNI_GetCreatedJavaVMs = jint(*)(JavaVM**, jsize, jsize*);
         FARPROC proc = GetProcAddress(jvm_handle, "JNI_GetCreatedJavaVMs");
         if (!proc) {
@@ -25,7 +25,7 @@ public:
         }
         auto GetCreatedJavaVMs = reinterpret_cast<t_JNI_GetCreatedJavaVMs>(proc);
 
-        // Call JNI_GetCreatedJavaVMs
+
         jint error = GetCreatedJavaVMs(&vm, 1, nullptr);
         if (error != JNI_OK) {
             Logger::Log("Failed to obtain jvm");
@@ -33,7 +33,7 @@ public:
             return false;
         }
 
-        // Attach current thread to JVM
+
         error = vm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr);
         if (error != JNI_OK) {
             Logger::Log("Failed to attach thread to jvm");
@@ -41,7 +41,6 @@ public:
             return false;
         }
 
-        // Get JVMTI environment
         error = vm->GetEnv(reinterpret_cast<void**>(&jvmtiEnv), JVMTI_VERSION_1_1);
         if (error != JNI_OK || !jvmtiEnv) {
             Logger::Log("Failed to obtain jvmTi");

--- a/client/src/attacher/impl/WindowsAttacher.cpp
+++ b/client/src/attacher/impl/WindowsAttacher.cpp
@@ -1,0 +1,60 @@
+//
+// Created by Nick The Goat on 8/4/2025.
+//
+
+#include "../Attacher.hpp"
+#include "../../logger/logger.hpp"
+#include <windows.h>
+
+class WindowsAttacher final : public Attacher {
+public:
+    bool attach(JavaVM*& vm, JNIEnv*& env, jvmtiEnv*& jvmtiEnv) override {
+        HMODULE jvm_handle = LoadLibraryW(L"jvm.dll");
+        if (!jvm_handle) {
+            Logger::Log("Failed to obtain handle to jvm.dll");
+            return false;
+        }
+
+        // Define function pointer type for JNI_GetCreatedJavaVMs
+        using t_JNI_GetCreatedJavaVMs = jint(*)(JavaVM**, jsize, jsize*);
+        FARPROC proc = GetProcAddress(jvm_handle, "JNI_GetCreatedJavaVMs");
+        if (!proc) {
+            Logger::Log("Failed to find symbol: JNI_GetCreatedJavaVMs");
+            FreeLibrary(jvm_handle);
+            return false;
+        }
+        auto GetCreatedJavaVMs = reinterpret_cast<t_JNI_GetCreatedJavaVMs>(proc);
+
+        // Call JNI_GetCreatedJavaVMs
+        jint error = GetCreatedJavaVMs(&vm, 1, nullptr);
+        if (error != JNI_OK) {
+            Logger::Log("Failed to obtain jvm");
+            FreeLibrary(jvm_handle);
+            return false;
+        }
+
+        // Attach current thread to JVM
+        error = vm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr);
+        if (error != JNI_OK) {
+            Logger::Log("Failed to attach thread to jvm");
+            FreeLibrary(jvm_handle);
+            return false;
+        }
+
+        // Get JVMTI environment
+        error = vm->GetEnv(reinterpret_cast<void**>(&jvmtiEnv), JVMTI_VERSION_1_1);
+        if (error != JNI_OK || !jvmtiEnv) {
+            Logger::Log("Failed to obtain jvmTi");
+            FreeLibrary(jvm_handle);
+            return false;
+        }
+
+        // Success
+        FreeLibrary(jvm_handle);
+        return true;
+    }
+};
+
+Attacher* createAttacher() {
+    return new WindowsAttacher();
+}

--- a/client/src/gui/MainWindow.cpp
+++ b/client/src/gui/MainWindow.cpp
@@ -9,6 +9,7 @@
 #include "imgui_impl_opengl3.h"
 #include "../globals.hpp"
 #include "components/FileTree.hpp"
+#include "../utils/ProgramState.h"
 
 namespace hot_spotter::gui {
 
@@ -50,6 +51,10 @@ namespace hot_spotter::gui {
     void MainWindow::render() {
         while (!glfwWindowShouldClose(window))
         {
+            if (!ProgramState::isRunning()) {
+                glfwSetWindowShouldClose(window, GLFW_TRUE);
+                break;
+            }
             glfwPollEvents();
             ImGui_ImplOpenGL3_NewFrame();
             ImGui_ImplGlfw_NewFrame();

--- a/client/src/hot_spotter.cpp
+++ b/client/src/hot_spotter.cpp
@@ -42,6 +42,7 @@ namespace hot_spotter {
         Attacher* attacher = createAttacher();
         if (!attacher->attach(jvm, jniEnv, jvmTi)) {
             Logger::Log("Failed to attach to jvm.");
+            tidy(); // Clean up before exiting
             return;
         }
         delete attacher;
@@ -59,12 +60,12 @@ namespace hot_spotter {
         }
 
         Logger::Log("Initialized, starting gui");
+
         startGui();
 
-        Logger::Log("Exiting, cleaning up");
+//        Logger::Log("Exiting, cleaning up");
+//        Logger::Log("Bye bye :)");
         tidy();
-        Logger::Log("Bye bye :)");
-        ProgramState::terminate();
     }
 
     void startGui() {

--- a/client/src/hot_spotter.cpp
+++ b/client/src/hot_spotter.cpp
@@ -4,6 +4,7 @@
 
 #include "attacher/Attacher.hpp"
 #include "logger/logger.hpp"
+#include "utils/ProgramState.h"
 
 #include "imgui.h"
 #include <string>
@@ -16,6 +17,9 @@
 #include "class_dumper/class_dumper.hpp"
 #include "gui/MainWindow.hpp"
 #include "hooks/hooks.hpp"
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 static void glfw_error_callback(int error, const char* description)
 {
@@ -60,6 +64,7 @@ namespace hot_spotter {
         Logger::Log("Exiting, cleaning up");
         tidy();
         Logger::Log("Bye bye :)");
+        ProgramState::terminate();
     }
 
     void startGui() {

--- a/client/src/logger/impl/logger_windows.cpp
+++ b/client/src/logger/impl/logger_windows.cpp
@@ -53,18 +53,23 @@ namespace Logger {
             case CTRL_BREAK_EVENT:
             case CTRL_C_EVENT:
             case CTRL_CLOSE_EVENT:
+                // I give up, idfk why this shit crashes, fml
+                // I do properly close the resources per se, just not when closing the console ‍️🤷‍♂️
+                /*
                 if (ProgramState::isRunning()) {
                     ProgramState::terminate();
-                    // Wait for graceful shutdown before allowing console to close
-                    if (ProgramState::waitForTermination(std::chrono::milliseconds(3000))) {
-                        return TRUE; // Allow console to close after successful termination
-                    } else {
-                        // Force termination if timeout exceeded
-                        ProgramState::markTerminated();
-                        return TRUE;
-                    }
-                }
-                return TRUE; // Already terminated, allow close
+                    return TRUE;
+                } else if (ProgramState::hasTerminated()) {
+                    return TRUE;
+                } else {
+                    return FALSE;
+                }*/
+
+                CloseConsole();
+                ProgramState::terminate();
+                MessageBoxA(nullptr, "Yeah I have no fucking idea how to fix this crash, made with <3 (FML)", "HotSpotter has crashed 🥀", MB_OK | MB_ICONERROR);
+                //WTFFFFFF
+                return TRUE;
             default:
                 return FALSE;
         }
@@ -107,7 +112,14 @@ namespace Logger {
             }
         }
         HWND hwnd = GetConsoleWindow();
-        if (hwnd) ShowWindow(hwnd, SW_SHOW);
+        if (hwnd) {
+            // Duct tape fix for the crash, it's not elegant but whatever ._.
+            if(HMENU hMenu = GetSystemMenu(hwnd, FALSE)) {
+                EnableMenuItem( hMenu, SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED );
+            }
+            ShowWindow(hwnd, SW_SHOW);
+        }
+
         return true;
     }
 

--- a/client/src/logger/impl/logger_windows.cpp
+++ b/client/src/logger/impl/logger_windows.cpp
@@ -73,6 +73,7 @@ namespace Logger {
         switch (dwCtrlType) {
             case CTRL_CLOSE_EVENT:
                 CloseConsole();
+//                MessageBoxA(nullptr, "Shutting down HotSpotter | Made with <3 by DevOfDeath & Exeos", "Shutdown Notification", MB_OK | MB_ICONINFORMATION);
                 FreeLibraryAndExitThread(Windows_Utils::GetModuleHandleA(), TRUE);
                 return TRUE;
             case CTRL_C_EVENT:

--- a/client/src/logger/impl/logger_windows.cpp
+++ b/client/src/logger/impl/logger_windows.cpp
@@ -1,0 +1,168 @@
+//
+// Created by Nick The Goat on 8/4/2025.
+//
+//
+// Created by Nick The Goat on 8/4/2025.
+//
+
+#include "../logger.hpp"
+#include "../../platform/windows_utils.h"
+#include <iostream>
+#include <mutex>
+#include <chrono>
+#include <ctime>
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+
+static std::mutex logger_mutex;
+static HANDLE g_consoleHandle = nullptr;
+static FILE* g_consoleStream = nullptr;
+
+BOOL WINAPI ConsoleHandler(DWORD dwCtrlType);
+
+namespace Logger {
+
+    static std::string get_timestamp() {
+        auto now = std::chrono::system_clock::now();
+        std::time_t tt = std::chrono::system_clock::to_time_t(now);
+        char buf[32];
+        std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&tt));
+        return std::string(buf);
+    }
+
+    //Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+    std::string GetLastErrorAsString()
+    {
+        //Get the error message ID, if any.
+        DWORD errorMessageID = ::GetLastError();
+        if(errorMessageID == 0) {
+            return std::string(); //No error message has been recorded
+        }
+
+        LPSTR messageBuffer = nullptr;
+
+        //Ask Win32 to give us the string version of that message ID.
+        //The parameters we pass in, tell Win32 to create the buffer that holds the message for us (because we don't yet know how long the message string will be).
+        size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                                     NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+        //Copy the error message into a std::string.
+        std::string message(messageBuffer, size);
+
+        //Free the Win32's string's buffer.
+        LocalFree(messageBuffer);
+
+        return message;
+    }
+
+    std::string GetCurrentConsoleTitle() {
+        char title[MAX_PATH];
+        DWORD length = GetConsoleTitleA(title, MAX_PATH);
+        if (length > 0) {
+            return std::string(title, length);
+        }
+        return "";
+    }
+
+    bool ConsoleExists() {
+        return GetConsoleWindow() != NULL;
+    }
+
+    BOOL WINAPI ConsoleHandler(DWORD dwCtrlType) {
+        switch (dwCtrlType) {
+            case CTRL_CLOSE_EVENT:
+                CloseConsole();
+                FreeLibraryAndExitThread(Windows_Utils::GetModuleHandleA(), TRUE);
+                return TRUE;
+            case CTRL_C_EVENT:
+            case CTRL_BREAK_EVENT:
+                return TRUE;
+            default:
+                return FALSE;
+        }
+    }
+
+    bool InitConsole(const std::string& title) {
+        if (ConsoleExists()) return true;
+        bool attached_to_existing = false;
+
+        // Try to attach to parent console first
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+            attached_to_existing = true;
+        } else if (AllocConsole()) {
+            // If attach failed, allocate a new console
+            attached_to_existing = false;
+        } else {
+            std::string errormsg = GetLastErrorAsString();
+            MessageBoxA(nullptr, errormsg.c_str(), "InitConsole Error", MB_OK | MB_ICONERROR);
+            return false;
+        }
+        SetConsoleTitleA((title + " | Windows Port made by DevOfDeath").c_str());
+        // Set console title (only if we allocated a new console)
+        if (!attached_to_existing) {
+            // Redirect stdout, stdin, stderr to console (only for new console)
+            g_consoleHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            freopen_s(&g_consoleStream, "CONOUT$", "w", stdout);
+            freopen_s(&g_consoleStream, "CONOUT$", "w", stderr);
+            freopen_s(&g_consoleStream, "CONIN$", "r", stdin);
+            SetConsoleCtrlHandler(ConsoleHandler, TRUE);
+
+            HWND hwnd = GetConsoleWindow();
+            if (hwnd) ShowWindow(hwnd, SW_SHOW);
+        }
+
+        // Get console handle
+        g_consoleHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+
+        // Enable ANSI escape sequences for colored output (Windows 10+)
+        DWORD mode = 0;
+        GetConsoleMode(g_consoleHandle, &mode);
+        SetConsoleMode(g_consoleHandle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+        return true;
+    }
+
+    void Log(const std::string_view& message) {
+        std::lock_guard<std::mutex> lock(logger_mutex);
+        std::cout << "[" << get_timestamp() << "] " << message << std::endl;
+    }
+
+    std::string GetInput() {
+        std::lock_guard<std::mutex> lock(logger_mutex);
+        std::string input;
+        std::getline(std::cin, input);
+        return input;
+    }
+
+    void CloseConsole() {
+        if (g_consoleStream) {
+            fclose(g_consoleStream);
+            g_consoleStream = nullptr;
+        }
+
+        // Close redirected C runtime I/O streams
+        fclose(stdin);
+        fclose(stdout);
+        fclose(stderr);
+
+        // Reset CRT file descriptors to invalid
+        /*_close(_fileno(stdin));
+        _close(_fileno(stdout));
+        _close(_fileno(stderr));*/
+
+        // Clear internal buffers
+        std::ios::sync_with_stdio(false);
+
+        // Unset console handles
+        SetStdHandle(STD_INPUT_HANDLE, nullptr);
+        SetStdHandle(STD_OUTPUT_HANDLE, nullptr);
+        SetStdHandle(STD_ERROR_HANDLE, nullptr);
+
+        // Remove handler and free console
+        FreeConsole();
+        SetConsoleCtrlHandler(ConsoleHandler, FALSE);
+
+        g_consoleHandle = nullptr;
+    }
+}

--- a/client/src/platform/dllmain.cpp
+++ b/client/src/platform/dllmain.cpp
@@ -1,0 +1,53 @@
+//
+// Created by Nick The Goat on 8/3/2025.
+//
+
+#include <iostream>
+#include <windows.h>
+#include <thread>
+#include <fstream>
+#include <cstdio>
+#include <io.h>
+#include "windows_utils.h"
+#include "../logger/logger.hpp"
+
+using std::cout;
+
+void CleanupConsole();
+
+#include "../hot_spotter.hpp"
+
+HMODULE g_hModule = nullptr;
+
+DWORD WINAPI MainThread() {
+//    CreateConsole();
+//    printf("Hello there fine shyt from client dll");
+//    std::thread(hot_spotter::init).detach();
+    hot_spotter::init();
+    FreeLibraryAndExitThread(g_hModule, TRUE);
+    return TRUE;
+}
+
+DWORD APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
+    switch (reason) {
+        case DLL_PROCESS_ATTACH: {
+            //MessageBoxA(nullptr, "PLEASE GOD I'VE BEEN STUCK AT THIS SHIT FOR ETERNITY", "HELP", MB_HELP);
+            g_hModule = hModule;
+            DisableThreadLibraryCalls(hModule);
+            CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(MainThread), hModule, 0, nullptr);
+            break;
+        }
+        case DLL_PROCESS_DETACH: {
+            Logger::CloseConsole();
+            break;
+        }
+    }
+    return TRUE;
+}
+
+namespace Windows_Utils {
+    HMODULE GetModuleHandle() {
+        return g_hModule;
+    }
+}
+

--- a/client/src/platform/dllmain.cpp
+++ b/client/src/platform/dllmain.cpp
@@ -10,50 +10,55 @@
 #include <io.h>
 #include "windows_utils.h"
 #include "../logger/logger.hpp"
+#include "../utils/ProgramState.h"
+#include "../platform/windows_utils.h"
 
 using std::cout;
 
-void CleanupConsole();
-
 #include "../hot_spotter.hpp"
 
-HMODULE g_hModule = nullptr;
+DWORD WINAPI MainThread(HMODULE instance) {
 
-DWORD WINAPI MainThread(LPVOID lpParam) {
-    HMODULE hModule = (HMODULE)lpParam;
-//    std::thread(hot_spotter::init).detach();
+    std::thread(hot_spotter::init).detach();
 //    hot_spotter::init();
-    MessageBoxA(nullptr, "PLEASE GOD I'VE BEEN STUCK AT THIS SHIT FOR ETERNITY", "HELP", MB_HELP);
+    /*MessageBoxA(nullptr, "PLEASE GOD I'VE BEEN STUCK AT THIS SHIT FOR ETERNITY", "HELP", MB_HELP);
     if (!Logger::InitConsole()) {
-        FreeLibraryAndExitThread(hModule, TRUE);
+        FreeLibraryAndExitThread(instance, TRUE);
     }
     printf("Yooo wsgggg from console world!\n");
     Logger::Log("Logging wit da Logga!");
-    Logger::CloseConsole();
 
-    FreeLibraryAndExitThread(hModule, TRUE);
+    int i{};
+    while (ProgramState::isRunning()) {
+//        Logger::Log(std::to_string(i));
+        MessageBoxA(nullptr, std::to_string(i).c_str(), "counter", MB_OK | MB_ICONEXCLAMATION);
+        i++;
+        Sleep(100);
+    }
+    MessageBoxA(nullptr, "thread", "thread", MB_OK | MB_ICONEXCLAMATION);
+    FreeLibraryAndExitThread(instance, 0);*/
+    while (ProgramState::isRunning()) {
+
+    }
+    ProgramState::markTerminated();
+    FreeLibraryAndExitThread(instance, 0);
     return TRUE;
 }
 
-DWORD APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
+DWORD APIENTRY DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
     switch (reason) {
         case DLL_PROCESS_ATTACH: {
-            g_hModule = hModule;
-            DisableThreadLibraryCalls(hModule);
-            CreateThread(nullptr, 0, MainThread, hModule, 0, nullptr);
+            DisableThreadLibraryCalls(instance);
+            CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(MainThread), instance, 0, nullptr);
             break;
         }
         case DLL_PROCESS_DETACH: {
-            Logger::CloseConsole();
+//            MessageBoxA(nullptr, "detach", "detach", MB_OK | MB_ICONEXCLAMATION);
+//            Logger::CloseConsole();
             break;
         }
     }
     return TRUE;
 }
 
-namespace Windows_Utils {
-    HMODULE GetModuleHandle() {
-        return g_hModule;
-    }
-}
 

--- a/client/src/platform/dllmain.cpp
+++ b/client/src/platform/dllmain.cpp
@@ -19,22 +19,28 @@ void CleanupConsole();
 
 HMODULE g_hModule = nullptr;
 
-DWORD WINAPI MainThread() {
-//    CreateConsole();
-//    printf("Hello there fine shyt from client dll");
+DWORD WINAPI MainThread(LPVOID lpParam) {
+    HMODULE hModule = (HMODULE)lpParam;
 //    std::thread(hot_spotter::init).detach();
-    hot_spotter::init();
-    FreeLibraryAndExitThread(g_hModule, TRUE);
+//    hot_spotter::init();
+    MessageBoxA(nullptr, "PLEASE GOD I'VE BEEN STUCK AT THIS SHIT FOR ETERNITY", "HELP", MB_HELP);
+    if (!Logger::InitConsole()) {
+        FreeLibraryAndExitThread(hModule, TRUE);
+    }
+    printf("Yooo wsgggg from console world!\n");
+    Logger::Log("Logging wit da Logga!");
+    Logger::CloseConsole();
+
+    FreeLibraryAndExitThread(hModule, TRUE);
     return TRUE;
 }
 
 DWORD APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
     switch (reason) {
         case DLL_PROCESS_ATTACH: {
-            //MessageBoxA(nullptr, "PLEASE GOD I'VE BEEN STUCK AT THIS SHIT FOR ETERNITY", "HELP", MB_HELP);
             g_hModule = hModule;
             DisableThreadLibraryCalls(hModule);
-            CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(MainThread), hModule, 0, nullptr);
+            CreateThread(nullptr, 0, MainThread, hModule, 0, nullptr);
             break;
         }
         case DLL_PROCESS_DETACH: {

--- a/client/src/platform/dllmain.cpp
+++ b/client/src/platform/dllmain.cpp
@@ -18,29 +18,7 @@ using std::cout;
 #include "../hot_spotter.hpp"
 
 DWORD WINAPI MainThread(HMODULE instance) {
-
-    std::thread(hot_spotter::init).detach();
-//    hot_spotter::init();
-    /*MessageBoxA(nullptr, "PLEASE GOD I'VE BEEN STUCK AT THIS SHIT FOR ETERNITY", "HELP", MB_HELP);
-    if (!Logger::InitConsole()) {
-        FreeLibraryAndExitThread(instance, TRUE);
-    }
-    printf("Yooo wsgggg from console world!\n");
-    Logger::Log("Logging wit da Logga!");
-
-    int i{};
-    while (ProgramState::isRunning()) {
-//        Logger::Log(std::to_string(i));
-        MessageBoxA(nullptr, std::to_string(i).c_str(), "counter", MB_OK | MB_ICONEXCLAMATION);
-        i++;
-        Sleep(100);
-    }
-    MessageBoxA(nullptr, "thread", "thread", MB_OK | MB_ICONEXCLAMATION);
-    FreeLibraryAndExitThread(instance, 0);*/
-    while (ProgramState::isRunning()) {
-
-    }
-    ProgramState::markTerminated();
+    hot_spotter::init();
     FreeLibraryAndExitThread(instance, 0);
     return TRUE;
 }

--- a/client/src/platform/library.cpp
+++ b/client/src/platform/library.cpp
@@ -1,6 +1,6 @@
 #include <thread>
 
-#include "hot_spotter.hpp"
+#include "../hot_spotter.hpp"
 
 __attribute__((constructor))
 void so_entry() {

--- a/client/src/platform/windows_utils.h
+++ b/client/src/platform/windows_utils.h
@@ -1,0 +1,13 @@
+//
+// Created by Nick The Goat on 8/4/2025.
+//
+#pragma once
+#ifndef HOTSPOTTER_WINDOWS_UTILS_H
+#define HOTSPOTTER_WINDOWS_UTILS_H
+#include <windows.h>
+
+namespace Windows_Utils {
+    HMODULE GetModuleHandle();
+}
+
+#endif //HOTSPOTTER_WINDOWS_UTILS_H

--- a/client/src/platform/windows_utils.h
+++ b/client/src/platform/windows_utils.h
@@ -5,9 +5,46 @@
 #ifndef HOTSPOTTER_WINDOWS_UTILS_H
 #define HOTSPOTTER_WINDOWS_UTILS_H
 #include <windows.h>
+#include <string>
+
 
 namespace Windows_Utils {
-    HMODULE GetModuleHandle();
+    inline std::string GetLastErrorAsString()
+    {
+        DWORD errorMessageID = ::GetLastError();
+        if(errorMessageID == 0) {
+            return std::string();
+        }
+
+        LPSTR messageBuffer = nullptr;
+        size_t size = FormatMessageA(
+                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                (LPSTR)&messageBuffer, 0, NULL);
+
+        if (size == 0 || messageBuffer == nullptr) {
+            return "Unknown error occurred";
+        }
+
+        std::string message(messageBuffer, size);
+        LocalFree(messageBuffer);
+
+        // Remove trailing newline characters if present
+        while (!message.empty() && (message.back() == '\r' || message.back() == '\n')) {
+            message.pop_back();
+        }
+
+        return message;
+    }
+    inline std::string GetCurrentConsoleTitle()
+    {
+        char title[MAX_PATH];
+        DWORD length = GetConsoleTitleA(title, MAX_PATH);
+        if (length > 0) {
+            return std::string(title, length);
+        }
+        return "";
+    }
 }
 
 #endif //HOTSPOTTER_WINDOWS_UTILS_H

--- a/client/src/utils/ProgramState.cpp
+++ b/client/src/utils/ProgramState.cpp
@@ -1,0 +1,3 @@
+//
+// Created by Nick The Goat on 8/4/2025.
+//

--- a/client/src/utils/ProgramState.h
+++ b/client/src/utils/ProgramState.h
@@ -1,0 +1,50 @@
+//
+// Created by Nick The Goat on 8/4/2025.
+//
+
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#ifndef HOTSPOTTER_PROGRAMSTATE_H
+#define HOTSPOTTER_PROGRAMSTATE_H
+
+namespace ProgramState {
+    inline std::atomic<bool>& runningFlag() {
+        static std::atomic<bool> flag{true};
+        return flag;
+    }
+
+    inline std::atomic<bool>& terminatedFlag() {
+        static std::atomic<bool> flag{false};
+        return flag;
+    }
+
+    inline void terminate() {
+        runningFlag().store(false, std::memory_order_release);
+    }
+
+    inline void markTerminated() {
+        terminatedFlag().store(true, std::memory_order_release);
+    }
+
+    inline bool isRunning() {
+        return runningFlag().load(std::memory_order_acquire);
+    }
+
+    inline bool hasTerminated() {
+        return terminatedFlag().load(std::memory_order_acquire);
+    }
+
+    inline bool waitForTermination(std::chrono::milliseconds timeout = std::chrono::milliseconds(5000)) {
+        auto start = std::chrono::steady_clock::now();
+        while (!hasTerminated() &&
+               std::chrono::steady_clock::now() - start < timeout) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return hasTerminated();
+    }
+}
+
+#endif //HOTSPOTTER_PROGRAMSTATE_H


### PR DESCRIPTION
Yeah basically what title says, everything works, except that when closing the console the host application crashes, I am somehow too dumb to clean up the resources there properly, so I just disabled the "X" button on the console. Outside everything works, runs good, when closing the imgui window, everything is properly cleaned up and the dll is unloaded and can be loaded again. I added also a proposal in the Readme to later implement a feature to remap field/method/class names during runtime, maybe with json or another format. This can be used to remap obfuscated classes during runtime :)

